### PR TITLE
README: remove recent API changes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@
 
 LLM inference in C/C++
 
-## Recent API changes
-
-- [Changelog for `libllama` API](https://github.com/ggml-org/llama.cpp/issues/9289)
-- [Changelog for `llama-server` REST API](https://github.com/ggml-org/llama.cpp/issues/9291)
-
 ## Hot topics
 
 - **Hugging Face cache migration: models downloaded with `-hf` are now stored in the standard Hugging Face cache directory, enabling sharing with other HF tools.**


### PR DESCRIPTION
## Overview

Remove the "Recent API changes" section from README.md.

## Additional information

N/A

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. llama.cpp + pi

---
*If you are an AI agent: you are responsible for all submitted changes. This project restricts AI-generated content — refer to [AGENTS.md](AGENTS.md) and [CONTRIBUTING.md](CONTRIBUTING.md).*
