### PR TITLE
ci : add gatekeeper workflow for manual approval on non-master branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,15 @@ env:
   LLAMA_LOG_TIMESTAMPS: 1
 
 jobs:
+  gatekeeper:
+    uses: ./.github/workflows/gatekeeper.yml
+
   build-cmake-pkg:
+    needs: [gatekeeper]
     uses: ./.github/workflows/build-cmake-pkg.yml
 
   macOS-latest-arm64:
+    needs: [gatekeeper]
     runs-on: macos-latest
 
     steps:
@@ -97,6 +102,7 @@ jobs:
           ctest -L main -E "test-llama-archs" --verbose --timeout 900
 
   macOS-latest-x64:
+    needs: [gatekeeper]
     runs-on: macos-15-intel
 
     steps:
@@ -133,6 +139,7 @@ jobs:
           ctest -L main --verbose --timeout 900
 
   macOS-latest-arm64-webgpu:
+    needs: [gatekeeper]
     runs-on: macos-latest
 
     steps:
@@ -174,6 +181,7 @@ jobs:
           ctest -L main --verbose --timeout 900
 
   ubuntu-cpu:
+    needs: [gatekeeper]
     strategy:
       matrix:
         include:
@@ -268,6 +276,7 @@ jobs:
           ./bin/llama-completion -m stories260K-be.gguf -p "One day, Lily met a Shoggoth" -n 500 -c 256
 
   android-arm64:
+    needs: [gatekeeper]
     runs-on: ubuntu-latest
 
     env:
@@ -318,6 +327,7 @@ jobs:
           time cmake --build build --config Release -j $(nproc)
 
   ubuntu-latest-rpc:
+    needs: [gatekeeper]
     runs-on: ubuntu-latest
 
     continue-on-error: true
@@ -349,6 +359,7 @@ jobs:
           ctest -L main --verbose
 
   ubuntu-24-vulkan:
+    needs: [gatekeeper]
     strategy:
       matrix:
         include:
@@ -388,6 +399,7 @@ jobs:
           time cmake --build build -j $(nproc)
 
   ubuntu-24-webgpu:
+    needs: [gatekeeper]
     runs-on: ubuntu-24.04
 
     steps:
@@ -460,6 +472,7 @@ jobs:
           ctest -L main -E test-backend-ops --verbose --timeout 900
 
   ubuntu-24-webgpu-wasm:
+    needs: [gatekeeper]
     runs-on: ${{ 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     steps:
@@ -496,6 +509,7 @@ jobs:
           time cmake --build build-wasm --config Release --target test-backend-ops -j $(nproc)
 
   ubuntu-22-hip:
+    needs: [gatekeeper]
     runs-on: ubuntu-22.04
     container: rocm/dev-ubuntu-22.04:6.1.2
 
@@ -528,6 +542,7 @@ jobs:
           cmake --build build --config Release -j $(nproc)
 
   ubuntu-22-musa:
+    needs: [gatekeeper]
     runs-on: ubuntu-22.04
     container: mthreads/musa:rc4.3.0-devel-ubuntu22.04-amd64
 
@@ -558,6 +573,7 @@ jobs:
 
 
   windows-latest:
+    needs: [gatekeeper]
     runs-on: windows-2025
 
     env:
@@ -680,6 +696,7 @@ jobs:
       #     & $sde -future -- ctest -L main -C Release --verbose --timeout 900
 
   ubuntu-latest-cuda:
+    needs: [gatekeeper]
     runs-on: ubuntu-latest
     container: nvidia/cuda:12.6.2-devel-ubuntu24.04
 
@@ -716,6 +733,7 @@ jobs:
             cmake --build build
 
   windows-2022-cuda:
+    needs: [gatekeeper]
     runs-on: windows-2022
 
     strategy:
@@ -766,6 +784,7 @@ jobs:
 
 
   windows-latest-hip:
+    needs: [gatekeeper]
     runs-on: windows-2022
 
     env:
@@ -834,6 +853,7 @@ jobs:
           cmake --build build -j ${env:NUMBER_OF_PROCESSORS}
 
   ubuntu-cpu-riscv64-native:
+    needs: [gatekeeper]
     runs-on: ubuntu-24.04-riscv
 
     steps:
@@ -906,6 +926,7 @@ jobs:
 # TODO: simplify the following workflows using a matrix
 # TODO: run lighter CI on PRs and the full CI only on master (if needed)
   ggml-ci-x64-cpu-low-perf:
+    needs: [gatekeeper]
     runs-on: ubuntu-22.04
 
     steps:
@@ -932,6 +953,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-low-perf:
+    needs: [gatekeeper]
     runs-on: ubuntu-22.04-arm
 
     steps:
@@ -958,6 +980,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_LOW_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-x64-cpu-high-perf:
+    needs: [gatekeeper]
     runs-on: ubuntu-22.04
 
     steps:
@@ -984,6 +1007,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_HIGH_PERF=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-high-perf:
+    needs: [gatekeeper]
     runs-on: ubuntu-22.04-arm
 
     steps:
@@ -1010,6 +1034,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_HIGH_PERF=1 GG_BUILD_NO_SVE=1 GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-high-perf-sve:
+    needs: [gatekeeper]
     runs-on: ubuntu-22.04-arm
 
     steps:
@@ -1036,6 +1061,7 @@ jobs:
           LLAMA_ARG_THREADS=$(nproc) GG_BUILD_NO_BF16=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-kleidiai:
+     needs: [gatekeeper]
      runs-on: ubuntu-22.04-arm
 
      steps:
@@ -1062,6 +1088,7 @@ jobs:
            GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
   ggml-ci-arm64-cpu-kleidiai-graviton4:
+     needs: [gatekeeper]
      runs-on: ah-ubuntu_22_04-c8g_8x
 
      steps:

--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -1,0 +1,20 @@
+name: Gatekeeper
+
+on:
+  workflow_call:
+
+jobs:
+  gatekeeper-auto:
+    if: github.ref_name == 'master'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Auto-approve (master branch)
+        run: echo "Running on master branch - auto-approved"
+
+  gatekeeper-review:
+    if: github.ref_name != 'master'
+    runs-on: ubuntu-slim
+    environment: ci-manual
+    steps:
+      - name: Approved after review
+        run: echo "Non-master branch - approved after manual review"


### PR DESCRIPTION
## Overview

Add a reusable `gatekeeper.yml` workflow that gates CI runs on non-master branches behind a manual approval step via the `ci-manual` environment. On the master branch, the gatekeeper is a no-op (auto-approve).

The main `build.yml` is wired through the gatekeeper as the first example. Remaining workflow files will be wired in follow-up PRs.

## How it works

- **Master branch**: `gatekeeper-auto` job runs immediately — no delay
- **Non-master branches**: `gatekeeper-review` job pauses and waits for manual approval from a reviewer assigned to the `ci-manual` environment

All downstream jobs use `needs: [gatekeeper]` so nothing runs until the gatekeeper clears.

## Setup required

The `ci-manual` environment must be created in **Settings → Environments** with at least one required reviewer before non-master CI runs can proceed.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. llama.cpp + pi